### PR TITLE
Remove repo_id field from codebase

### DIFF
--- a/src/api/files.py
+++ b/src/api/files.py
@@ -30,13 +30,11 @@ class ProcessFileResponse(BaseModel):
     success: bool
     message: str
     file_path: str
-    repo_id: str
     processed_at: str
 
 
 class FileIndexResponse(BaseModel):
     """Response model for file index information."""
-    repo_id: str
     file_path: str
     file_hash: str
     last_commit_sha: str
@@ -75,7 +73,7 @@ async def process_file(
         # Process the file using FileIndexer
         # The FileIndexer will automatically parse the file_content to extract exports and imports
         success = await indexer.process_file(
-            repo_id=request.repo_url,
+            repo_url=request.repo_url,
             file_path=request.file_path,
             commit_sha=request.commit_sha,
             file_timestamp=request.file_timestamp,
@@ -96,7 +94,6 @@ async def process_file(
             success=True,
             message="File processed successfully",
             file_path=request.file_path,
-            repo_id=request.repo_url,
             processed_at=processed_at
         )
         
@@ -131,7 +128,6 @@ async def get_file_index(
             )
         
         return FileIndexResponse(
-            repo_id=file_index.repoId,
             file_path=file_index.filePath,
             file_hash=file_index.fileHash,
             last_commit_sha=file_index.lastCommitSHA,
@@ -171,7 +167,6 @@ async def list_repository_files(
         responses = []
         for file_index in file_indexes:
             response = FileIndexResponse(
-                repo_id=file_index.repoId,
                 file_path=file_index.filePath,
                 file_hash=file_index.fileHash,
                 last_commit_sha=file_index.lastCommitSHA,

--- a/src/core/locks.py
+++ b/src/core/locks.py
@@ -19,18 +19,18 @@ class FileLock:
     Lock key format: {repoId}:{filePath} (NO commit SHA in lock key)
     """
     
-    def __init__(self, repo_id: str, file_path: str, ttl_seconds: int = 300):
+    def __init__(self, repo_url: str, file_path: str, ttl_seconds: int = 300):
         """
         Initialize file lock.
         
         Args:
-            repo_id: Repository identifier
+            repo_url: Repository URL identifier
             file_path: Relative path within repository
             ttl_seconds: Lock TTL in seconds (default: 5 minutes)
         """
-        self.repo_id = repo_id
+        self.repo_url = repo_url
         self.file_path = file_path
-        self.lock_key = f"{repo_id}:{file_path}"
+        self.lock_key = f"{repo_url}:{file_path}"
         self.ttl_seconds = ttl_seconds
         self.acquired_at: Optional[datetime] = None
         self.lock_doc_ref: Optional[firestore.DocumentReference] = None
@@ -78,7 +78,7 @@ class FileLock:
             if not lock_doc.exists:
                 # No existing lock, create new one
                 transaction.set(self.lock_doc_ref, {
-                    'repo_id': self.repo_id,
+                    'repo_url': self.repo_url,
                     'file_path': self.file_path,
                     'acquired_at': now,
                     'expires_at': lock_expires_at,

--- a/src/core/repository_indexer.py
+++ b/src/core/repository_indexer.py
@@ -162,7 +162,7 @@ class RepositoryIndexer:
     
     async def _process_repository_files(
         self,
-        repo_id: str,
+        repo_url: str,
         repo_path: str,
         file_paths: List[str],
         commit_sha: str,
@@ -172,7 +172,7 @@ class RepositoryIndexer:
         Process multiple files in a repository.
         
         Args:
-            repo_id: Repository identifier
+            repo_url: Repository identifier
             repo_path: Path to repository root
             file_paths: List of file paths to process
             commit_sha: Commit SHA
@@ -203,7 +203,7 @@ class RepositoryIndexer:
                 
                 # Process the file using FileIndexer
                 success = await self.file_indexer.process_file(
-                    repo_id=repo_id,
+                    repo_url=repo_url,
                     file_path=file_path,
                     commit_sha=commit_sha,
                     file_timestamp=commit_timestamp,


### PR DESCRIPTION
Remove `repo_id` field and replace with `repo_url` for data model cleanup and improved consistency.

---
Linear Issue: [CLO-15](https://linear.app/cloud-brain/issue/CLO-15/remove-repo-id-field-from-codebase-files)

<a href="https://cursor.com/background-agent?bcId=bc-da8d2b3d-9943-4481-b5ae-2bab5e50a3e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da8d2b3d-9943-4481-b5ae-2bab5e50a3e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

